### PR TITLE
fix: consistent naming of config files on read and write

### DIFF
--- a/TrustedTravelFabric/src/main/java/me/lukasabbe/trustedtravelfabric/config/Config.java
+++ b/TrustedTravelFabric/src/main/java/me/lukasabbe/trustedtravelfabric/config/Config.java
@@ -26,7 +26,7 @@ public class Config {
     }
 
     private void createAndLoadConfig() throws FileNotFoundException {
-        Path configPath = FabricLoader.getInstance().getConfigDir().resolve("servers.yml");
+        Path configPath = FabricLoader.getInstance().getConfigDir().resolve("config.yml");
         if(!Files.exists(configPath)) createConfigFile(configPath);
 
         Yaml yaml = new Yaml();


### PR DESCRIPTION
Fixes a bug where the plugin would write an empty servers.yml file only when a config.yml file was present. This caused the wrong file to be loaded on server start.